### PR TITLE
Add support for rebinding queries.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,12 @@ module go.step.sm/sequel
 go 1.21
 
 require (
+	github.com/go-sqlx/sqlx v1.3.8
+	github.com/jackc/pgx/v5 v5.5.5
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.30.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.30.0
+	go.step.sm/qb v1.4.0
 )
 
 require (
@@ -17,6 +20,7 @@ require (
 	github.com/containerd/containerd v1.7.12 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.5.0 // indirect
 	github.com/docker/docker v25.0.5+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
@@ -42,6 +46,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
@@ -64,13 +69,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230711160842-782d3b101e98 // indirect
 	google.golang.org/grpc v1.58.3 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
-)
-
-require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/go-sqlx/sqlx v1.3.8
-	github.com/jackc/pgx/v5 v5.5.5
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.step.sm/qb v1.3.0
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -148,8 +148,8 @@ go.opentelemetry.io/otel/trace v1.24.0 h1:CsKnnL4dUAr/0llH9FKuc698G04IrpWV0MQA/Y
 go.opentelemetry.io/otel/trace v1.24.0/go.mod h1:HPc3Xr/cOApsBI154IU0OI0HJexz+aw5uPdbs3UCjNU=
 go.opentelemetry.io/proto/otlp v1.0.0 h1:T0TX0tmXU8a3CbNXzEKGeU5mIVOdf0oykP+u2lIVU/I=
 go.opentelemetry.io/proto/otlp v1.0.0/go.mod h1:Sy6pihPLfYHkr3NkUbEhGHFhINUSI/v80hjKIs5JXpM=
-go.step.sm/qb v1.3.0 h1:+EM326xJQsX9vHPATMTAa2YqIeYlpvUuKPuZj8V/xM4=
-go.step.sm/qb v1.3.0/go.mod h1:V+B0IstgCmVyM27km7OImv90GsvtuUhNczxRkIDW4qo=
+go.step.sm/qb v1.4.0 h1:U0jCLu7UADtJeZbd19ZFonu+a7mFfoL6KPKGPWRYW+c=
+go.step.sm/qb v1.4.0/go.mod h1:V+B0IstgCmVyM27km7OImv90GsvtuUhNczxRkIDW4qo=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/helpers.go
+++ b/helpers.go
@@ -65,6 +65,6 @@ func NullString(s string) sql.NullString {
 // if the zero value is given.
 func NullTime(t time.Time) sql.NullTime {
 	return sql.NullTime{
-		Time: t, Valid: t.IsZero(),
+		Time: t, Valid: !t.IsZero(),
 	}
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,36 @@
+package sequel
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHelpers(t *testing.T) {
+	assert.Equal(t, sql.NullBool{Bool: true, Valid: true}, NullBool(true))
+	assert.Equal(t, sql.NullBool{Bool: false, Valid: false}, NullBool(false))
+
+	assert.Equal(t, sql.NullByte{Byte: 1, Valid: true}, NullByte(1))
+	assert.Equal(t, sql.NullByte{Byte: 0, Valid: false}, NullByte(0))
+
+	assert.Equal(t, sql.NullFloat64{Float64: 1.1, Valid: true}, NullFloat64(1.1))
+	assert.Equal(t, sql.NullFloat64{Float64: 0, Valid: false}, NullFloat64(0))
+
+	assert.Equal(t, sql.NullInt16{Int16: 1, Valid: true}, NullInt16(1))
+	assert.Equal(t, sql.NullInt16{Int16: 0, Valid: false}, NullInt16(0))
+
+	assert.Equal(t, sql.NullInt32{Int32: 1, Valid: true}, NullInt32(1))
+	assert.Equal(t, sql.NullInt32{Int32: 0, Valid: false}, NullInt32(0))
+
+	assert.Equal(t, sql.NullInt64{Int64: 1, Valid: true}, NullInt64(1))
+	assert.Equal(t, sql.NullInt64{Int64: 0, Valid: false}, NullInt64(0))
+
+	assert.Equal(t, sql.NullString{String: "abc", Valid: true}, NullString("abc"))
+	assert.Equal(t, sql.NullString{String: "", Valid: false}, NullString(""))
+
+	now := time.Now()
+	assert.Equal(t, sql.NullTime{Time: now, Valid: true}, NullTime(now))
+	assert.Equal(t, sql.NullTime{Time: time.Time{}, Valid: false}, NullTime(time.Time{}))
+}


### PR DESCRIPTION
This commit adds new methods for rebinding queries. This allows multiple databases to be supported using queries with the bind parameter `?`.
