### PR TITLE
Copy ci permissions to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ permissions:
 
 jobs:
   ci:
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     uses: smallstep/sequel/.github/workflows/ci.yml@main
     secrets: inherit
 


### PR DESCRIPTION
Attempting to fix [this release error](https://github.com/smallstep/sequel/actions/runs/23510938122) when pushing a tag.
